### PR TITLE
Makes the ctrl-c safe for every stage during booting. 

### DIFF
--- a/python/vineyard/deploy/tests/test_distributed.py
+++ b/python/vineyard/deploy/tests/test_distributed.py
@@ -18,6 +18,7 @@
 
 import itertools
 import json
+import time
 
 import pandas as pd
 import pytest
@@ -77,6 +78,38 @@ def test_add_remote_placeholder(vineyard_ipc_sockets):
 
     meta = client2.get_meta(tupid, True)
     assert meta['__elements_-size'] == 4
+
+
+def test_add_remote_placeholder_with_sync(vineyard_ipc_sockets):
+    vineyard_ipc_sockets = list(itertools.islice(itertools.cycle(vineyard_ipc_sockets), 4))
+
+    client1 = vineyard.connect(vineyard_ipc_sockets[0])
+    client2 = vineyard.connect(vineyard_ipc_sockets[1])
+    client3 = vineyard.connect(vineyard_ipc_sockets[2])
+    client4 = vineyard.connect(vineyard_ipc_sockets[3])
+
+    data = np.ones((1, 2, 3, 4, 5))
+
+    o1 = client1.put(data)
+    client1.persist(o1)
+    time.sleep(5)
+
+    o2 = client2.put(data)
+    client2.persist(o2)
+    time.sleep(5)
+
+    o3 = client3.put(data)
+    client3.persist(o3)
+    time.sleep(5)
+
+    o4 = client4.put(data)
+    client4.persist(o4)
+    time.sleep(5)
+
+    client1.get_meta(o4)
+    client2.get_meta(o1)
+    client3.get_meta(o2)
+    client4.get_meta(o3)
 
 
 def test_remote_deletion(vineyard_ipc_sockets):

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -88,7 +88,10 @@ void IPCServer::doAccept() {
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }
-    doAccept();
+    // don't continue when the iocontext being cancelled.
+    if (!stopped_.load()) {
+      doAccept();
+    }
   });
 }
 

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -76,7 +76,10 @@ void RPCServer::doAccept() {
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }
-    doAccept();
+    // don't continue when the iocontext being cancelled.
+    if (!stopped_.load()) {
+      doAccept();
+    }
   });
 }
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -40,9 +40,7 @@ void SocketConnection::Start() {
   doReadHeader();
 }
 
-void SocketConnection::Stop() {
-  doStop();
-}
+void SocketConnection::Stop() { doStop(); }
 
 void SocketConnection::doReadHeader() {
   auto self(this->shared_from_this());
@@ -945,8 +943,7 @@ void SocketConnection::doAsyncWrite(callback_t<> callback) {
 }
 
 SocketServer::SocketServer(vs_ptr_t vs_ptr)
-    : vs_ptr_(vs_ptr), next_conn_id_(0) {
-}
+    : vs_ptr_(vs_ptr), next_conn_id_(0) {}
 
 void SocketServer::Start() {
   stopped_.store(false);
@@ -954,7 +951,10 @@ void SocketServer::Start() {
 }
 
 void SocketServer::Stop() {
-  stopped_.store(true);
+  if (stopped_.exchange(true)) {
+    return;
+  }
+
   std::lock_guard<std::mutex> scope_lock(this->connections_mutx_);
   for (auto& pair : connections_) {
     pair.second->Stop();

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -33,29 +33,25 @@ SocketConnection::SocketConnection(stream_protocol::socket socket,
     : socket_(std::move(socket)),
       server_ptr_(server_ptr),
       socket_server_ptr_(socket_server_ptr),
-      conn_id_(conn_id),
-      running_(false) {}
+      conn_id_(conn_id) {}
 
 void SocketConnection::Start() {
-  running_ = true;
+  running_.store(true);
   doReadHeader();
 }
 
 void SocketConnection::Stop() {
   doStop();
-  running_ = false;
 }
 
 void SocketConnection::doReadHeader() {
   auto self(this->shared_from_this());
   asio::async_read(socket_, asio::buffer(&read_msg_header_, sizeof(size_t)),
                    [this, self](boost::system::error_code ec, std::size_t) {
-                     if (!ec && running_) {
+                     if (!ec && running_.load()) {
                        doReadBody();
                      } else {
                        doStop();
-                       socket_server_ptr_->RemoveConnection(conn_id_);
-                       return;
                      }
                    });
 }
@@ -75,16 +71,14 @@ void SocketConnection::doReadBody() {
   auto self(shared_from_this());
   asio::async_read(socket_, asio::buffer(&read_msg_body_[0], read_msg_header_),
                    [this, self](boost::system::error_code ec, std::size_t) {
-                     if ((!ec || ec == asio::error::eof) && running_) {
+                     if ((!ec || ec == asio::error::eof) && running_.load()) {
                        bool exit = processMessage(read_msg_body_);
                        if (exit || ec == asio::error::eof) {
                          doStop();
-                         socket_server_ptr_->RemoveConnection(conn_id_);
                          return;
                        }
                      } else {
                        doStop();
-                       socket_server_ptr_->RemoveConnection(conn_id_);
                        return;
                      }
                      // start next-round read
@@ -407,7 +401,7 @@ bool SocketConnection::doGetData(const json& root) {
   TRY_READ_REQUEST(ReadGetDataRequest(root, ids, sync_remote, wait));
   json tree;
   RESPONSE_ON_ERROR(server_ptr_->GetData(
-      ids, sync_remote, wait, [self]() { return self->running_; },
+      ids, sync_remote, wait, [self]() { return self->running_.load(); },
       [self](const Status& status, const json& tree) {
         std::string message_out;
         if (status.ok()) {
@@ -699,7 +693,7 @@ bool SocketConnection::doGetName(const json& root) {
   bool wait;
   TRY_READ_REQUEST(ReadGetNameRequest(root, name, wait));
   RESPONSE_ON_ERROR(server_ptr_->GetName(
-      name, wait, [self]() { return self->running_; },
+      name, wait, [self]() { return self->running_.load(); },
       [self](const Status& status, const ObjectID& object_id) {
         std::string message_out;
         if (status.ok()) {
@@ -889,15 +883,25 @@ void SocketConnection::doWrite(std::string&& buf) {
 }
 
 void SocketConnection::doStop() {
-  // On Mac the state of socket may be "not connected" after the client has
-  // already closed the socket, hence there will be an exception.
-  boost::system::error_code ec;
-  socket_.shutdown(stream_protocol::socket::shutdown_both, ec);
-  socket_.close();
+  if (!running_.exchange(false)) {
+    // already stopped, or haven't started
+    return;
+  }
+
   // do cleanup: clean up streams associated with this client
   for (auto stream_id : associated_streams_) {
     VINEYARD_SUPPRESS(server_ptr_->GetStreamStore()->Drop(stream_id));
   }
+
+  // On Mac the state of socket may be "not connected" after the client has
+  // already closed the socket, hence there will be an exception.
+  boost::system::error_code ec;
+  socket_.cancel(ec);
+  socket_.shutdown(stream_protocol::socket::shutdown_both, ec);
+  socket_.close(ec);
+
+  // drop connection
+  socket_server_ptr_->RemoveConnection(conn_id_);
 }
 
 void SocketConnection::doAsyncWrite() {
@@ -913,7 +917,6 @@ void SocketConnection::doAsyncWrite() {
                         }
                       } else {
                         doStop();
-                        socket_server_ptr_->RemoveConnection(conn_id_);
                       }
                     });
 }
@@ -933,22 +936,25 @@ void SocketConnection::doAsyncWrite(callback_t<> callback) {
             auto status = callback(Status::OK());
             if (!status.ok()) {
               doStop();
-              socket_server_ptr_->RemoveConnection(conn_id_);
             }
           }
         } else {
           doStop();
-          socket_server_ptr_->RemoveConnection(conn_id_);
         }
       });
 }
 
 SocketServer::SocketServer(vs_ptr_t vs_ptr)
-    : vs_ptr_(vs_ptr), next_conn_id_(0) {}
+    : vs_ptr_(vs_ptr), next_conn_id_(0) {
+}
 
-void SocketServer::Start() { doAccept(); }
+void SocketServer::Start() {
+  stopped_.store(false);
+  doAccept();
+}
 
 void SocketServer::Stop() {
+  stopped_.store(true);
   std::lock_guard<std::mutex> scope_lock(this->connections_mutx_);
   for (auto& pair : connections_) {
     pair.second->Stop();
@@ -963,13 +969,19 @@ bool SocketServer::ExistsConnection(int conn_id) const {
 
 void SocketServer::RemoveConnection(int conn_id) {
   std::lock_guard<std::mutex> scope_lock(this->connections_mutx_);
-  connections_.erase(conn_id);
+  auto conn = connections_.find(conn_id);
+  if (conn != connections_.end()) {
+    connections_.erase(conn);
+  }
 }
 
 void SocketServer::CloseConnection(int conn_id) {
   std::lock_guard<std::mutex> scope_lock(this->connections_mutx_);
-  connections_.at(conn_id)->Stop();
-  RemoveConnection(conn_id);
+  auto conn = connections_.find(conn_id);
+  if (conn != connections_.end()) {
+    conn->second->Stop();
+    connections_.erase(conn);
+  }
 }
 
 size_t SocketServer::AliveConnections() const {

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef SRC_SERVER_ASYNC_SOCKET_SERVER_H_
 #define SRC_SERVER_ASYNC_SOCKET_SERVER_H_
 
+#include <atomic>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -159,7 +160,7 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
   vs_ptr_t server_ptr_;
   SocketServer* socket_server_ptr_;
   int conn_id_;
-  bool running_;
+  std::atomic_bool running_;
 
   asio::streambuf buf_;
   socket_message_queue_t write_msgs_;
@@ -211,6 +212,7 @@ class SocketServer {
   size_t AliveConnections() const;
 
  protected:
+  std::atomic_bool stopped_;  // if the socket server being stopped.
   vs_ptr_t vs_ptr_;
   int next_conn_id_;
   std::unordered_map<int, std::shared_ptr<SocketConnection>> connections_;

--- a/src/server/server/vineyard_server.cc
+++ b/src/server/server/vineyard_server.cc
@@ -793,18 +793,22 @@ void VineyardServer::Stop() {
   meta_guard_.reset();
   if (this->ipc_server_ptr_) {
     this->ipc_server_ptr_->Stop();
-    this->ipc_server_ptr_.reset(nullptr);
   }
   if (this->rpc_server_ptr_) {
     this->rpc_server_ptr_->Stop();
-    this->rpc_server_ptr_.reset(nullptr);
   }
-
-  meta_service_ptr_->Stop();
+  if (this->meta_service_ptr_) {
+    this->meta_service_ptr_->Stop();
+  }
 
   // stop the asio context at last
   context_.stop();
   meta_context_.stop();
+
+  // cleanup
+  this->ipc_server_ptr_.reset(nullptr);
+  this->rpc_server_ptr_.reset(nullptr);
+  this->meta_service_ptr_.reset();
 
   // wait for the IO context finishes.
   for (auto& worker : workers_) {

--- a/src/server/server/vineyard_server.h
+++ b/src/server/server/vineyard_server.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef SRC_SERVER_SERVER_VINEYARD_SERVER_H_
 #define SRC_SERVER_SERVER_VINEYARD_SERVER_H_
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <set>
@@ -166,6 +167,8 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
 
   void Stop();
 
+  bool Running() const;
+
   ~VineyardServer();
 
  private:
@@ -208,7 +211,7 @@ class VineyardServer : public std::enable_shared_from_this<VineyardServer> {
     kReady = 0b1111,
   };
   unsigned char ready_;
-  bool stopped_;  // avoid invoke Stop() twice.
+  std::atomic_bool stopped_;  // avoid invoke Stop() twice.
 
   InstanceID instance_id_;
   std::string hostname_;

--- a/src/server/services/etcd_meta_service.cc
+++ b/src/server/services/etcd_meta_service.cc
@@ -227,4 +227,9 @@ void EtcdMetaService::retryDaeminWatch(
   });
 }
 
+Status EtcdMetaService::preStart() {
+  auto launcher = EtcdLauncher(etcd_spec_);
+  return launcher.LaunchEtcdServer(etcd_, meta_sync_lock_, etcd_proc_);
+}
+
 }  // namespace vineyard

--- a/src/server/services/meta_service.h
+++ b/src/server/services/meta_service.h
@@ -128,9 +128,9 @@ class IMetaService {
   static std::shared_ptr<IMetaService> Get(vs_ptr_t);
 
   inline Status Start() {
-    LOG(INFO) << "start!";
+    LOG(INFO) << "meta service is starting ...";
+    RETURN_ON_ERROR(this->preStart());
     RETURN_ON_ERROR(this->probe());
-    rev_ = 0;
     requestValues("",
                   [this](const Status& status, const json& meta, unsigned rev) {
                     if (status.ok()) {
@@ -147,7 +147,7 @@ class IMetaService {
     return Status::OK();
   }
 
-  virtual inline void Stop() { LOG(INFO) << "stop!"; }
+  virtual inline void Stop() { LOG(INFO) << "meta service is stopping ..."; }
 
  public:
   inline void RequestToBulkUpdate(
@@ -563,6 +563,8 @@ class IMetaService {
   std::string meta_sync_lock_;
 
  private:
+  virtual Status preStart() { return Status::OK(); }
+
   bool deleteable(ObjectID const object_id);
 
   void traverseToDelete(std::set<ObjectID>& initial_delete_set,

--- a/src/server/vineyardd.cc
+++ b/src/server/vineyardd.cc
@@ -54,6 +54,7 @@ int main(int argc, char* argv[]) {
   // restore the default signal handling, when "vineyardd" is launched inside
   // a bash script.
   sigset(SIGINT, SIG_DFL);
+
   FLAGS_stderrthreshold = 0;
   vineyard::logging::InitGoogleLogging("vineyard");
   vineyard::logging::InstallFailureSignalHandler();
@@ -85,8 +86,18 @@ int main(int argc, char* argv[]) {
   ProfilerStart(profiling.c_str());
 #endif
 
-  VINEYARD_CHECK_OK(server_ptr_->Serve());
-  VINEYARD_CHECK_OK(server_ptr_->Finalize());
+  {
+    auto status = server_ptr_->Serve();
+    if (server_ptr_->Running()) {
+      VINEYARD_CHECK_OK(status);
+    }
+  }
+  {
+    auto status = server_ptr_->Finalize();
+    if (server_ptr_->Running()) {
+      VINEYARD_CHECK_OK(status);
+    }
+  }
 
 #if defined(WITH_PROFILING)
   ProfilerStop();

--- a/test/invalid_connect_test.cc
+++ b/test/invalid_connect_test.cc
@@ -1,0 +1,91 @@
+/** Copyright 2021 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "arrow/status.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
+#include "glog/logging.h"
+
+#include "basic/ds/array.h"
+#include "client/client.h"
+#include "client/ds/object_meta.h"
+#include "client/rpc_client.h"
+#include "common/backtrace/backtrace.hpp"
+
+using namespace vineyard;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    printf("usage ./invalid_connect_test <ipc_socket> <rpc_endpoint>");
+    return 1;
+  }
+  std::string ipc_socket(argv[1]);
+  std::string rpc_endpoint(argv[2]);
+
+  // valid
+
+  Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+  LOG(INFO) << "ipc socket is: " << client.IPCSocket();
+  LOG(INFO) << "rpc endpoint is: " << client.RPCEndpoint();
+
+  RPCClient rpc_client;
+  VINEYARD_CHECK_OK(rpc_client.Connect(rpc_endpoint));
+  LOG(INFO) << "Connected to RPCServer: " << rpc_endpoint;
+
+  LOG(INFO) << "ipc socket is: " << client.IPCSocket();
+  LOG(INFO) << "rpc endpoint is: " << client.RPCEndpoint();
+
+  // invalid
+
+  {
+    Client invalid;
+    auto s1 = client.Connect("/connect/to/some/where");
+    LOG(INFO) << s1.ToString();
+    CHECK(s1.IsAssertionFailed() || s1.IsIOError() || s1.IsConnectionFailed());
+  }
+
+  {
+    RPCClient invalid;
+    auto s1 = client.Connect("/connect/to/some/where");
+    LOG(INFO) << s1.ToString();
+    CHECK(s1.IsAssertionFailed() || s1.IsIOError() || s1.IsConnectionFailed());
+  }
+
+  {
+    RPCClient invalid;
+    auto s1 = client.Connect("invalid-host.com");
+    LOG(INFO) << s1.ToString();
+    CHECK(s1.IsAssertionFailed() || s1.IsIOError() || s1.IsConnectionFailed());
+  }
+
+  // test libunwind and backtrace
+
+  backtrace_info::backtrace(std::cout, true);
+  backtrace_info::backtrace(std::cout, false);
+
+  LOG(INFO) << "Passed invalid connect tests...";
+
+  client.Disconnect();
+
+  return 0;
+}

--- a/test/invalid_connect_test.cc
+++ b/test/invalid_connect_test.cc
@@ -80,8 +80,10 @@ int main(int argc, char** argv) {
 
   // test libunwind and backtrace
 
+#if defined(WITH_LIBUNWIND)
   backtrace_info::backtrace(std::cout, true);
   backtrace_info::backtrace(std::cout, false);
+#endif
 
   LOG(INFO) << "Passed invalid connect tests...";
 

--- a/test/runner.py
+++ b/test/runner.py
@@ -233,6 +233,7 @@ def run_single_vineyardd_tests(etcd_endpoints):
                          'vineyard_test_%s' % time.time(),
                          default_ipc_socket=VINEYARD_CI_IPC_SOCKET) as (_, rpc_socket_port):
         run_test('array_test')
+        run_test('allocator_test')
         run_test('arrow_data_structure_test')
         run_test('dataframe_test')
         run_test('delete_test')
@@ -241,6 +242,7 @@ def run_single_vineyardd_tests(etcd_endpoints):
         run_test('global_object_test')
         run_test('hashmap_test')
         run_test('id_test')
+        run_test('invalid_connect_test', '127.0.0.1:%d' % rpc_socket_port)
         run_test('large_meta_test')
         run_test('list_object_test')
         run_test('name_test')

--- a/test/runner.py
+++ b/test/runner.py
@@ -165,7 +165,8 @@ mpiexec_cmdargs = resolve_mpiexec_cmdargs()
 
 
 def run_test(test_name, *args, nproc=1, capture=False, vineyard_ipc_socket=VINEYARD_CI_IPC_SOCKET):
-    print('running test case -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-  %s  -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-' % test_name)
+    print(f'running test case -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-  {test_name}  -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-',
+          flush=True)
     arg_reps = []
     for arg in args:
         if isinstance(arg, str):


### PR DESCRIPTION
Eliminate the exceptions when killing the server, and it may help the coverage rate as well.