### PR TITLE
Fixes stacktrace by avoiding use TLS sections.

### DIFF
--- a/modules/graph/utils/error.h
+++ b/modules/graph/utils/error.h
@@ -118,19 +118,15 @@ inline grape::OutArchive& operator>>(grape::OutArchive& archive, GSError& e) {
 #define TOKENPASTE(x, y) x##y
 #define TOKENPASTE2(x, y) TOKENPASTE(x, y)
 
-// FIXME: the backtrace seems corrupt the heap
-//
-//  vineyard::backtrace_info::backtrace(TOKENPASTE2(_ss, __LINE__), true);
-//
-#define RETURN_GS_ERROR(code, msg)                                      \
-  do {                                                                  \
-    std::stringstream TOKENPASTE2(_ss, __LINE__);                       \
+#define RETURN_GS_ERROR(code, msg)                                         \
+  do {                                                                     \
+    std::stringstream TOKENPASTE2(_ss, __LINE__);                          \
     vineyard::backtrace_info::backtrace(TOKENPASTE2(_ss, __LINE__), true); \
-    return ::boost::leaf::new_error(vineyard::GSError(                  \
-        (code),                                                         \
-        std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + \
-            std::string(__FUNCTION__) + " -> " + (msg),                 \
-        TOKENPASTE2(_ss, __LINE__).str()));                             \
+    return ::boost::leaf::new_error(vineyard::GSError(                     \
+        (code),                                                            \
+        std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " +    \
+            std::string(__FUNCTION__) + " -> " + (msg),                    \
+        TOKENPASTE2(_ss, __LINE__).str()));                                \
   } while (0)
 
 #define BOOST_LEAF_ASSIGN(v, r)                                     \

--- a/modules/graph/utils/error.h
+++ b/modules/graph/utils/error.h
@@ -125,6 +125,7 @@ inline grape::OutArchive& operator>>(grape::OutArchive& archive, GSError& e) {
 #define RETURN_GS_ERROR(code, msg)                                      \
   do {                                                                  \
     std::stringstream TOKENPASTE2(_ss, __LINE__);                       \
+    vineyard::backtrace_info::backtrace(TOKENPASTE2(_ss, __LINE__), true); \
     return ::boost::leaf::new_error(vineyard::GSError(                  \
         (code),                                                         \
         std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " + \

--- a/src/common/backtrace/backtrace.hpp
+++ b/src/common/backtrace/backtrace.hpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cxxabi.h>
 
 #ifdef WITH_LIBUNWIND
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #endif
 
@@ -33,12 +34,22 @@ struct backtrace_info {
   static void backtrace(std::ostream& _out,
                         bool const compact = false) noexcept {
 #ifdef WITH_LIBUNWIND
-    thread_local char symbol[1024];
+    char symbol[1024];
+    // thread_local char symbol[1024];
     unw_cursor_t cursor;
     unw_context_t context;
     unw_getcontext(&context);
     unw_init_local(&cursor, &context);
     _out << std::hex << std::uppercase;
+    // reuse the output buffer, for how `__cxa_demangle` works, see:
+    //
+    // https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html
+    //
+    // and
+    //
+    // https://github.com/gcc-mirror/gcc/blob/master/libiberty/cp-demangle.c
+    std::unique_ptr<char, decltype(std::free)&> demangled_name{nullptr, std::free};
+    size_t demangled_size = 0;
     while (0 < unw_step(&cursor)) {
       unw_word_t ip = 0;
       unw_get_reg(&cursor, UNW_REG_IP, &ip);
@@ -52,8 +63,9 @@ struct backtrace_info {
       print_reg(_out, sp);
       _out << ") ";
       unw_word_t offset = 0;
+      // unw_get_proc_name guarantees the result buffer is NULL terminated.
       if (unw_get_proc_name(&cursor, symbol, sizeof(symbol), &offset) == 0) {
-        _out << "(" << get_demangled_name(symbol) << " + 0x" << offset << ")\n";
+        _out << "(" << get_demangled_name(symbol, demangled_name, demangled_size) << " + 0x" << offset << ")\n";
         if (!compact) {
           _out << "\n";
         }
@@ -65,22 +77,19 @@ struct backtrace_info {
 #endif
   }
 
-  static char const* get_demangled_name(char const* const symbol) noexcept {
-    thread_local std::unique_ptr<char, decltype(std::free)&> demangled_name{
-        nullptr, std::free};
-    // reuse the output buffer, for how `__cxa_demangle` works, see:
-    // https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html
-    thread_local size_t buffer_length = 0;
+  static char const* get_demangled_name(char const* const symbol, std::unique_ptr<char, decltype(std::free)&> & demangled_name,
+                                        size_t &demangled_size) noexcept {
     if (!symbol) {
       return "<null>";
     }
+    // return symbol;
     int status = -4;
-    size_t buffer_length_next = buffer_length;
+    size_t buffer_length = demangled_size;
     demangled_name.reset(abi::__cxa_demangle(symbol, demangled_name.release(),
-                                             &buffer_length_next, &status));
+                                             &buffer_length, &status));
     if (status == 0) {
-      buffer_length = buffer_length > buffer_length_next ? buffer_length
-                                                         : buffer_length_next;
+      demangled_size = buffer_length > demangled_size ? buffer_length
+                                                         : demangled_size;
       return demangled_name.get();
     } else {
       return symbol;

--- a/src/common/backtrace/backtrace_on_terminate.hpp
+++ b/src/common/backtrace/backtrace_on_terminate.hpp
@@ -55,8 +55,10 @@ std::unique_ptr<std::remove_pointer_t<std::terminate_handler>,
                 << e.what() << std::endl;
     } catch (...) {
       if (std::type_info* et = abi::__cxa_current_exception_type()) {
+        std::unique_ptr<char, decltype(std::free)&> demangled_name{nullptr, std::free};
+        size_t demangled_size = 0;
         std::clog << "backtrace: unhandled exception type: "
-                  << backtrace_info::get_demangled_name(et->name())
+                  << backtrace_info::get_demangled_name(et->name(), demangled_name, demangled_size)
                   << std::endl;
       } else {
         std::clog << "backtrace: unhandled unknown exception" << std::endl;

--- a/src/common/backtrace/backtrace_on_terminate.hpp
+++ b/src/common/backtrace/backtrace_on_terminate.hpp
@@ -55,10 +55,12 @@ std::unique_ptr<std::remove_pointer_t<std::terminate_handler>,
                 << e.what() << std::endl;
     } catch (...) {
       if (std::type_info* et = abi::__cxa_current_exception_type()) {
-        std::unique_ptr<char, decltype(std::free)&> demangled_name{nullptr, std::free};
+        std::unique_ptr<char, decltype(std::free)&> demangled_name{nullptr,
+                                                                   std::free};
         size_t demangled_size = 0;
         std::clog << "backtrace: unhandled exception type: "
-                  << backtrace_info::get_demangled_name(et->name(), demangled_name, demangled_size)
+                  << backtrace_info::get_demangled_name(
+                         et->name(), demangled_name, demangled_size)
                   << std::endl;
       } else {
         std::clog << "backtrace: unhandled unknown exception" << std::endl;


### PR DESCRIPTION
Looks that TLS doens't work well with `dlopen`. In GraphScope, every analytical app are `.so` and being dlopen before executing.