### PR TITLE
Make sure the vineyard server is gracefully stopped.

### DIFF
--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -99,7 +99,8 @@ void IPCServer::doAccept() {
           std::make_shared<SocketConnection>(std::move(this->socket_), vs_ptr_,
                                              this, next_conn_id_);
       conn->Start();
-      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
+      std::lock_guard<std::recursive_mutex> scope_lock(
+          this->connections_mutex_);
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }

--- a/src/server/async/ipc_server.cc
+++ b/src/server/async/ipc_server.cc
@@ -99,7 +99,7 @@ void IPCServer::doAccept() {
           std::make_shared<SocketConnection>(std::move(this->socket_), vs_ptr_,
                                              this, next_conn_id_);
       conn->Start();
-      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -72,7 +72,8 @@ void RPCServer::doAccept() {
           std::make_shared<SocketConnection>(std::move(this->socket_), vs_ptr_,
                                              this, next_conn_id_);
       conn->Start();
-      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
+      std::lock_guard<std::recursive_mutex> scope_lock(
+          this->connections_mutex_);
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }

--- a/src/server/async/rpc_server.cc
+++ b/src/server/async/rpc_server.cc
@@ -72,7 +72,7 @@ void RPCServer::doAccept() {
           std::make_shared<SocketConnection>(std::move(this->socket_), vs_ptr_,
                                              this, next_conn_id_);
       conn->Start();
-      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+      std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
       connections_.emplace(next_conn_id_, conn);
       ++next_conn_id_;
     }

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -955,20 +955,20 @@ void SocketServer::Stop() {
     return;
   }
 
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
+  std::vector<int> connection_ids_;
   for (auto& pair : connections_) {
     pair.second->Stop();
   }
-  connections_.clear();
 }
 
 bool SocketServer::ExistsConnection(int conn_id) const {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
   return connections_.find(conn_id) != connections_.end();
 }
 
 void SocketServer::RemoveConnection(int conn_id) {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
   auto conn = connections_.find(conn_id);
   if (conn != connections_.end()) {
     connections_.erase(conn);
@@ -976,7 +976,7 @@ void SocketServer::RemoveConnection(int conn_id) {
 }
 
 void SocketServer::CloseConnection(int conn_id) {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
   auto conn = connections_.find(conn_id);
   if (conn != connections_.end()) {
     conn->second->Stop();
@@ -985,7 +985,7 @@ void SocketServer::CloseConnection(int conn_id) {
 }
 
 size_t SocketServer::AliveConnections() const {
-  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutx_);
+  std::lock_guard<std::recursive_mutex> scope_lock(this->connections_mutex_);
   return connections_.size();
 }
 

--- a/src/server/async/socket_server.cc
+++ b/src/server/async/socket_server.cc
@@ -35,12 +35,33 @@ SocketConnection::SocketConnection(stream_protocol::socket socket,
       socket_server_ptr_(socket_server_ptr),
       conn_id_(conn_id) {}
 
-void SocketConnection::Start() {
+bool SocketConnection::Start() {
   running_.store(true);
   doReadHeader();
+
+  return true;
 }
 
-void SocketConnection::Stop() { doStop(); }
+bool SocketConnection::Stop() {
+  if (!running_.exchange(false)) {
+    // already stopped, or haven't started
+    return false;
+  }
+
+  // do cleanup: clean up streams associated with this client
+  for (auto stream_id : associated_streams_) {
+    VINEYARD_SUPPRESS(server_ptr_->GetStreamStore()->Drop(stream_id));
+  }
+
+  // On Mac the state of socket may be "not connected" after the client has
+  // already closed the socket, hence there will be an exception.
+  boost::system::error_code ec;
+  socket_.cancel(ec);
+  socket_.shutdown(stream_protocol::socket::shutdown_both, ec);
+  socket_.close(ec);
+
+  return true;
+}
 
 void SocketConnection::doReadHeader() {
   auto self(this->shared_from_this());
@@ -881,25 +902,10 @@ void SocketConnection::doWrite(std::string&& buf) {
 }
 
 void SocketConnection::doStop() {
-  if (!running_.exchange(false)) {
-    // already stopped, or haven't started
-    return;
+  if (this->Stop()) {
+    // drop connection
+    socket_server_ptr_->RemoveConnection(conn_id_);
   }
-
-  // do cleanup: clean up streams associated with this client
-  for (auto stream_id : associated_streams_) {
-    VINEYARD_SUPPRESS(server_ptr_->GetStreamStore()->Drop(stream_id));
-  }
-
-  // On Mac the state of socket may be "not connected" after the client has
-  // already closed the socket, hence there will be an exception.
-  boost::system::error_code ec;
-  socket_.cancel(ec);
-  socket_.shutdown(stream_protocol::socket::shutdown_both, ec);
-  socket_.close(ec);
-
-  // drop connection
-  socket_server_ptr_->RemoveConnection(conn_id_);
 }
 
 void SocketConnection::doAsyncWrite() {

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -49,12 +49,12 @@ class SocketConnection : public std::enable_shared_from_this<SocketConnection> {
   SocketConnection(stream_protocol::socket socket, vs_ptr_t server_ptr,
                    SocketServer* socket_server_ptr, int conn_id);
 
-  void Start();
+  bool Start();
 
   /**
    * @brief Invoke internal doStop, and set the running status to false.
    */
-  void Stop();
+  bool Stop();
 
  protected:
   bool doRegister(const json& root);

--- a/src/server/async/socket_server.h
+++ b/src/server/async/socket_server.h
@@ -216,7 +216,7 @@ class SocketServer {
   vs_ptr_t vs_ptr_;
   int next_conn_id_;
   std::unordered_map<int, std::shared_ptr<SocketConnection>> connections_;
-  mutable std::recursive_mutex connections_mutx_;  // protect `connections_`
+  mutable std::recursive_mutex connections_mutex_;  // protect `connections_`
 
  private:
   virtual void doAccept() = 0;


### PR DESCRIPTION
In previous implementation, in `Stop()`, we:

1. traverse the `connections_` map
2. delete item from the `connections_` map

at the same time...

This pull request will fixes #270.