### PR TITLE
Update the Apache Arrow web link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ third-party libraries may not have the same license as vineyard.
 Acknowledgements
 ----------------
 
-- `apache-arrow <https://github.com/apache-arrow/granula>`_, a cross-language development platform for in-memory analytics;
+- `apache-arrow <https://github.com/apache/arrow>`_, a cross-language development platform for in-memory analytics;
 - `boost-leaf <https://github.com/boostorg/leaf>`_, a C++ lightweight error augmentation framework;
 - `dlmalloc <http://gee.cs.oswego.edu/dl/html/malloc.htmlp>`_, Doug Lea's memory allocator;
 - `etcd-cpp-apiv3 <https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3>`_, a C++ API for etcd's v3 client API;


### PR DESCRIPTION
The Apache Arrow web link is wrong. Correct it.